### PR TITLE
Bugfix - parameter path in workflow

### DIFF
--- a/patterns/alz/examples/sample-workflow.yml
+++ b/patterns/alz/examples/sample-workflow.yml
@@ -34,4 +34,4 @@ jobs:
         id: deploy_amba
         shell: bash
         run: |
-          az deployment mg create --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/alzArm.json --location ${{ env.Location }} --management-group-id ${{ env.ManagementGroupPrefix }} --parameters .\patterns\alz\alzArm.param.json
+          az deployment mg create --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/alzArm.json --location ${{ env.Location }} --management-group-id ${{ env.ManagementGroupPrefix }} --parameters ./patterns/alz/alzArm.param.json


### PR DESCRIPTION
The GitHub Actions workflow fails to run on Linux workers when the parameters path is using backslashes. This PR changes the path to use slashes.

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes

1. https://github.com/Azure/azure-monitor-baseline-alerts/issues/30

### Breaking Changes

None.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
